### PR TITLE
Improve API and Gradio error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ ENV/
 *.sublime-project
 *.sublime-workspace
 
+.gradio/

--- a/docuparse/fastapi_app.py
+++ b/docuparse/fastapi_app.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, File, UploadFile, Form
+from fastapi import FastAPI, File, UploadFile, Form, HTTPException
 from fastapi.responses import PlainTextResponse
+import os
 import tempfile
 
 from .converter import convert_pdf_to_markdown
@@ -12,9 +13,20 @@ async def convert_endpoint(
     file: UploadFile = File(...), max_pages: int | None = Form(None)
 ) -> str:
     """Convert an uploaded PDF and return Markdown."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
-        contents = await file.read()
-        tmp.write(contents)
-        tmp.flush()
-        text = convert_pdf_to_markdown(tmp.name, max_pages=max_pages)
-    return text
+    tmp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+            tmp_name = tmp.name
+            contents = await file.read()
+            tmp.write(contents)
+            tmp.flush()
+        text = convert_pdf_to_markdown(tmp_name, max_pages=max_pages)
+        return text
+    except ModuleNotFoundError as e:
+        # Dependency for PDF conversion is missing
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:  # pragma: no cover - runtime errors
+        raise HTTPException(status_code=500, detail=f"Failed to convert PDF: {e}")
+    finally:
+        if tmp_name and os.path.exists(tmp_name):
+            os.unlink(tmp_name)

--- a/docuparse/gradio_app.py
+++ b/docuparse/gradio_app.py
@@ -1,15 +1,25 @@
+from typing import Any
+
 import requests
 import gradio as gr
 
 API_URL = "http://localhost:8000/convert"
 
-def convert_pdf(file: gr.files.FileData, max_pages: int | None) -> str:
+
+def convert_pdf(file: Any, max_pages: int | None) -> str:
     """Send PDF to the API and return Markdown text."""
+    if max_pages is not None:
+        max_pages = int(max_pages)
     with open(file.name, "rb") as f:
         files = {"file": (file.name, f, "application/pdf")}
         data = {"max_pages": max_pages} if max_pages is not None else {}
-        resp = requests.post(API_URL, files=files, data=data)
-        resp.raise_for_status()
+        try:
+            resp = requests.post(API_URL, files=files, data=data)
+            resp.raise_for_status()
+        except requests.RequestException as e:  # pragma: no cover - network errors
+            if e.response is not None:
+                return f"API error {e.response.status_code}: {e.response.text}"
+            return f"Request failed: {e}"
     return resp.text
 
 iface = gr.Interface(

--- a/start_apps.sh
+++ b/start_apps.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to handle cleanup on script exit
+cleanup() {
+    echo -e "\n${YELLOW}Shutting down applications...${NC}"
+    # Kill all background jobs started by this script
+    jobs -p | xargs -r kill
+    exit 0
+}
+
+# Set up trap to handle Ctrl+C
+trap cleanup SIGINT SIGTERM
+
+echo -e "${GREEN}Starting DocuParse Applications...${NC}"
+echo -e "${BLUE}================================================${NC}"
+
+# Start backend (FastAPI with uvicorn)
+echo -e "${GREEN}Starting Backend (FastAPI)...${NC}"
+uvicorn docuparse.fastapi_app:app --reload &
+BACKEND_PID=$!
+
+# Give backend a moment to start
+sleep 2
+
+# Start frontend (Gradio)
+echo -e "${GREEN}Starting Frontend (Gradio)...${NC}"
+python3 docuparse/gradio_app.py &
+FRONTEND_PID=$!
+
+echo -e "${BLUE}================================================${NC}"
+echo -e "${GREEN}Both applications are starting up...${NC}"
+echo -e "${YELLOW}Backend PID: $BACKEND_PID${NC}"
+echo -e "${YELLOW}Frontend PID: $FRONTEND_PID${NC}"
+echo -e "${BLUE}================================================${NC}"
+echo -e "${RED}Press Ctrl+C to stop both applications${NC}"
+
+# Wait for both processes
+wait


### PR DESCRIPTION
## Summary
- handle conversion failures in FastAPI endpoint with helpful HTTP errors and cleanup
- make Gradio client more robust to API failures and casting

## Testing
- `python -m py_compile docuparse/fastapi_app.py docuparse/gradio_app.py`
- `pytest`
- `python - <<'PY'
from fastapi.testclient import TestClient
from docuparse.fastapi_app import app

client = TestClient(app)
with open('data/sample.pdf', 'rb') as f:
    resp = client.post('/convert', files={'file': ('sample.pdf', f, 'application/pdf')})
    print('status', resp.status_code)
    print('text', resp.text[:50])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6898b897bd3883298fd53755b33cdc70